### PR TITLE
Updated variable declarations and added COM object release

### DIFF
--- a/Init.vb
+++ b/Init.vb
@@ -1,16 +1,17 @@
-﻿Imports AlibreX
+﻿Imports System.Runtime.InteropServices
+Imports AlibreX
 Imports System.Threading
 Module Init
     Sub Main()
-        Dim Hook As IAutomationHook
-        Dim Root As IADRoot
+        Dim Hook As IAutomationHook = Nothing
+        Dim Root As IADRoot = Nothing
+        Dim Session As IADSession = Nothing
+        Dim FeatureStep As IADPartSession = Nothing
         Try
-            Dim Session As IADSession
-            Dim FeatureStep As AlibreX.IADPartSession
             Hook = GetObject(, "AlibreX.AutomationHook")
             Root = Hook.Root
             Session = Root.TopmostSession
-            FeatureStep = Session
+            FeatureStep = CType(Session, IADPartSession)
             FeatureStep.Features.Item(0).IsActive = True
             Thread.Sleep(TimeSpan.FromSeconds(0.5))
             For Each item As IADPartFeature In FeatureStep.Features
@@ -22,8 +23,22 @@ Module Init
         Catch ex As ArgumentException
             Console.WriteLine(ex.Message)
         Finally
-            Hook = Nothing
-            Root = Nothing
+            If Not IsNothing(FeatureStep) Then
+                Marshal.ReleaseComObject(FeatureStep)
+                FeatureStep = Nothing
+            End If
+            If Not IsNothing(Session) Then
+                Marshal.ReleaseComObject(Session)
+                Session = Nothing
+            End If
+            If Not IsNothing(Root) Then
+                Marshal.ReleaseComObject(Root)
+                Root = Nothing
+            End If
+            If Not IsNothing(Hook) Then
+                Marshal.ReleaseComObject(Hook)
+                Hook = Nothing
+            End If
         End Try
     End Sub
 End Module


### PR DESCRIPTION
Updated the `Imports` statement to include `System.Runtime.InteropServices` and `System.Threading` namespaces for using `Marshal` and `Thread` classes. Initialized `Hook`, `Root`, `Session`, and `FeatureStep` variables to `Nothing` and cast `FeatureStep` to `IADPartSession` type. Added `Marshal.ReleaseComObject` method in the `Finally` block to release COM objects before discarding them.